### PR TITLE
pissarro: firmware: Fix the Makefile Guard

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -8,7 +8,7 @@
 
 LOCAL_PATH := $(call my-dir)
 
-ifneq ($(strip pissarro $(TARGET_DEVICE)),)
+ifeq ($(TARGET_DEVICE),pissarro)
 
 $(info Including firmware for pissarro...)
 


### PR DESCRIPTION
The current Makefile Guard was useless and was including the firmware on non-pissarro devices (and it was not getting included in pissarro itself)!